### PR TITLE
Fix : Error when -m is not present

### DIFF
--- a/check_disks_by_ssh.py
+++ b/check_disks_by_ssh.py
@@ -151,8 +151,8 @@ if __name__ == '__main__':
         print "Error : hostname parameter (-H) is mandatory"
         sys.exit(2)
 
-    mounts = opts.mounts.split(',')
-    if mounts:
+    if opt.mounts:
+        mounts = opts.mounts.split(',')
         MOUNTS=mounts
 
     ssh_key_file = opts.ssh_key_file or os.path.expanduser('~/.ssh/id_rsa')


### PR DESCRIPTION
When option -m is not present, we have this error : 

```
Traceback (most recent call last):
  File "./check_disks_by_ssh.py", line 154, in <module>
    mounts = opts.mounts.split(',')
AttributeError: 'NoneType' object has no attribute 'split'`
```

As, -m in not mandatory, this pull request seems to fix the error.
