### PR TITLE
memory check: fix division by 0 when swap_total==0

### DIFF
--- a/check_memory_by_ssh.py
+++ b/check_memory_by_ssh.py
@@ -153,7 +153,7 @@ if __name__ == '__main__':
         perfdata += ' %s=%s%%;%s;%s;0%%;100%%' % (k, int(100 * float(v)/total), _warn, _crit)
 
     # Add swap if required (actually no check supported)
-    if opts.swap :
+    if opts.swap and swap_total > 0:
         d_swap = {'swap_used':swap_used, 'swap_free':swap_free}
         for (k,v) in d_swap.iteritems():
             perfdata += ' %s=%s%%;;;0%%;100%%' % (k, int(100 * float(v)/swap_total))
@@ -164,7 +164,7 @@ if __name__ == '__main__':
         d['total']=total
         for (k,v) in d.iteritems():
             perfdata += ' %s=%sKB;;;0KB;%sKB' % (k+'_abs', v, total) 
-        if opts.swap:
+        if opts.swap and swap_total > 0:
             d_swap['swap_total']=swap_total
             for (k,v) in d_swap.iteritems():
                 perfdata += ' %s=%sKB;;;0KB;%sKB' % (k, v, swap_total) 


### PR DESCRIPTION
Memory check fails when ``swap_total==0`` and invoked ``-s`` which is the default. This commit ensures we have valid data before rendering the results.