### PR TITLE
Use user ssh_config if a ProxyCommand is specified (to allow tunnelling)

### DIFF
--- a/schecks.py
+++ b/schecks.py
@@ -100,17 +100,17 @@ def connect(hostname, port, ssh_key_file, passphrase, user):
     user_config_file = os.path.expanduser("~/.ssh/config")
     if os.path.exists(user_config_file):
         with open(user_config_file) as f:
-            options = ssh_config.parse(f)
+            ssh_config.parse(f)
 
-        cfg = {'hostname': hostname, 'port': port, 'username': user, 'key_filename': ssh_key_file, 'password': passphrase}
+    cfg = {'hostname': hostname, 'port': port, 'username': user, 'key_filename': ssh_key_file, 'password': passphrase}
 
-        user_config = ssh_config.lookup(cfg['hostname'])
-        for k in ('hostname', 'port', 'username', 'key_filename', 'password'):
-            if k in user_config:
-                cfg[k] = user_config[k]
+    user_config = ssh_config.lookup(cfg['hostname'])
+    for k in ('hostname', 'port', 'username', 'key_filename', 'password'):
+        if k in user_config:
+            cfg[k] = user_config[k]
 
-        if 'proxycommand' in user_config:
-            cfg['sock'] = paramiko.ProxyCommand(user_config['proxycommand'])
+    if 'proxycommand' in user_config:
+        cfg['sock'] = paramiko.ProxyCommand(user_config['proxycommand'])
 
     try:
         client.connect(**cfg)

--- a/schecks.py
+++ b/schecks.py
@@ -95,9 +95,25 @@ def connect(hostname, port, ssh_key_file, passphrase, user):
     client = paramiko.SSHClient()
     client.load_system_host_keys()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy()) 
+
+    ssh_config = paramiko.SSHConfig()
+    user_config_file = os.path.expanduser("~/.ssh/config")
+    if os.path.exists(user_config_file):
+        with open(user_config_file) as f:
+            options = ssh_config.parse(f)
+
+        cfg = {'hostname': hostname, 'port': port, 'username': user, 'key_filename': ssh_key_file, 'password': passphrase}
+
+        user_config = ssh_config.lookup(cfg['hostname'])
+        for k in ('hostname', 'port', 'username', 'key_filename', 'password'):
+            if k in user_config:
+                cfg[k] = user_config[k]
+
+        if 'proxycommand' in user_config:
+            cfg['sock'] = paramiko.ProxyCommand(user_config['proxycommand'])
+
     try:
-        client.connect(hostname, port=port, username=user,
-                       key_filename=ssh_key_file, password=passphrase)
+        client.connect(**cfg)
     except Exception, exp:
         err = "Error : connexion failed '%s'" % exp
         print err


### PR DESCRIPTION
I wanted to use the shinken user's /home/shinken/.ssh/config file for hosts that need to tunnel SSH via another host first. The following is how I achieved this.