### PR TITLE
Change hashbangs to python2

### DIFF
--- a/check_cpu_stats_by_ssh.py
+++ b/check_cpu_stats_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_disks_by_ssh.py
+++ b/check_disks_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013-:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_disks_stats_by_ssh.py
+++ b/check_disks_stats_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_kernel_stats_by_ssh.py
+++ b/check_kernel_stats_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_linux.py
+++ b/check_linux.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013-:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_load_average_by_ssh.py
+++ b/check_load_average_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_mdadm_by_ssh.py
+++ b/check_mdadm_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_memory_by_ssh.py
+++ b/check_memory_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_net_stats_by_ssh.py
+++ b/check_net_stats_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_nfs_stats_by_ssh.py
+++ b/check_nfs_stats_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_ntp_sync_by_ssh.py
+++ b/check_ntp_sync_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_processes_by_ssh.py
+++ b/check_processes_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_ro_filesystem_by_ssh.py
+++ b/check_ro_filesystem_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_ssh_connexion.py
+++ b/check_ssh_connexion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_ssh_proxy_check.py
+++ b/check_ssh_proxy_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_tcp_states_by_ssh.py
+++ b/check_tcp_states_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/check_uptime_by_ssh.py
+++ b/check_uptime_by_ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com

--- a/checks/disks.py
+++ b/checks/disks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013-:
 #     Gabes Jean, naparuba@gmail.com

--- a/checks/disks_stats.py
+++ b/checks/disks_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013-:
 #     Gabes Jean, naparuba@gmail.com

--- a/schecks.py
+++ b/schecks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2013:
 #     Gabes Jean, naparuba@gmail.com


### PR DESCRIPTION
Using shinken on distributions where Python3 is the default was impossible due to Python2 only compatibility and incorrect hashbangs (``#!/usr/bin/env python``).

By explicitly telling python2 in hashbangs, Shinken still works on systems where there is only python2, and also compatible on systems where there is both Python2 and Python3 (and primarily on systems where python3 is the default).

This pull request change all hashbangs from ``#!/usr/bin/env python`` to ``#!/usr/bin/env python2``