### PR TITLE
check_memory_by_ssh.py: free on rhel7 change the calcul mode of used 

### DIFF
--- a/check_memory_by_ssh.py
+++ b/check_memory_by_ssh.py
@@ -176,7 +176,7 @@ if __name__ == '__main__':
         if opts.swap:
             d_swap['swap_total']=swap_total
             for (k,v) in d_swap.iteritems():
-                perfdata += ' %s=%sB;;;0;%s' % (k, v*1024, swap_total*1024)
+                perfdata += ' %s=%sB;;;0;%s' % (k+'_abs', v*1024, swap_total*1024)
 
 
     # And compare to limits

--- a/check_memory_by_ssh.py
+++ b/check_memory_by_ssh.py
@@ -57,13 +57,23 @@ def get_meminfo(client):
     #      TOTAL      USED        FREE          SHARED  BUF        CACHED
     stdin, stdout, stderr = client.exec_command('LC_ALL=C free -k')
     total = used = free = shared = buffed = cached = 0
+    is_available = 0
     for line in stdout:
         line = line.strip()
-        
+
+        # free on redhat 7 return :
+        #              total        used        free      shared  buff/cache   available
+        #Mem:        1877688      124584      708416       98708     1044688     1456760
+        # used (rhel7) = consumed
+        if line.endswith('available'):
+            is_available = 1
         if line.startswith('Mem'):
             tmp = line.split(':')
             # We will have a [2064856, 1736636, 328220, 0, 142880, 413184]
             total, used, free, shared, buffed, cached = (int(v) for v in  tmp[1].split(' ') if v)
+            if is_available == 1: # correction for new version of free command to match with the old one
+                cached=0
+                used=total-free
         
         if line.startswith('Swap'):
             # We will have a [4385148          0   14385148]


### PR DESCRIPTION
the command free has change on RHEL7, field are not the same : 
in old linux : 
# free -k
             total       used       free     shared    buffers     cached
Mem:       8057792    6401856    1655936          0     463348    1582792
-/+ buffers/cache:    4355716    3702076
Swap:      2097144      98736    1998408

in new linux (redhat el7)
$ free -k
              total        used        free      shared  buff/cache   available
Mem:        1877688      124584      708416       98708     1044688     1456760
Swap:       1679356           0     1679356

used = total - free - buff/cache 
here : "used" is your consumed calculate value.

cached field = available
when the first line end with available, we set cached variable containt available value... set the variable to 0. 


best regards,
