### PR TITLE
Fix excluded_interfaces None error on check_net_stats_by_ssh.py

### DIFF
--- a/check_net_stats_by_ssh.py
+++ b/check_net_stats_by_ssh.py
@@ -107,7 +107,7 @@ def get_net_stats(client):
         tmp = line.split(':', 1)
         ifname = tmp[0]
         # We don't care about lo
-        if ifname.startswith('lo') or ifname.startswith(tuple(excluded_interfaces)):
+        if ifname.startswith('lo') or (excluded_interfaces is not None and ifname.startswith(tuple(excluded_interfaces))):
             continue
         values = tmp[1]
 


### PR DESCRIPTION
Fix excluded_interfaces None error if not --excluded not specified