### PR TITLE
Fix decimal point character (LC_NUMERIC)

### DIFF
--- a/check_cpu_stats_by_ssh.py
+++ b/check_cpu_stats_by_ssh.py
@@ -51,7 +51,7 @@ def get_mpstat(client):
     #Average:       3    2.00    0.00    1.00    0.00    0.00    0.00    0.00    0.00   97.00
 
     # Beware of the export!
-    stdin, stdout, stderr = client.exec_command('export LC_LANG=C && unset LANG && mpstat -P ALL 1 1')
+    stdin, stdout, stderr = client.exec_command('export LC_LANG=C && unset LANG && LC_NUMERIC=en_US.UTF-8 mpstat -P ALL 1 1')
     stats = {}
 
     pos = {'%usr':-1, '%nice':-1, '%sys':-1, '%iowait':-1, '%irq':-1, '%soft':-1, '%steal':-1, '%guest':-1, '%idle':-1}


### PR DESCRIPTION
Running mpstat with different LC_NUMERIC locales cause different outputs. This is a problem in remote machines with LC_NUMERIC set to a non-english locale.

For example, using es_ES locale, the result is given with "," as decimal point char.

```
# LC_NUMERIC=es_ES.UTF-8 mpstat
12:03:25     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
12:03:25     all    9,23    0,01    3,18    0,31    0,00    0,23    0,24    0,00    0,00   86,81
```

instead of the expected "." char:

```
# LC_NUMERIC=en_US.UTF-8 mpstat
12:03:39     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
12:03:39     all    9.23    0.01    3.18    0.31    0.00    0.23    0.24    0.00    0.00   86.81
```

This change will set explicitly set LC_NUMERIC locate to an english locale in order to avoid this problem. It is used as a local environment variable of the mpstat binary, a better approach than exporting to the shell IMHO.