### PR TITLE
Fix mpstat output due locale problems

### DIFF
--- a/check_cpu_stats_by_ssh.py
+++ b/check_cpu_stats_by_ssh.py
@@ -51,7 +51,7 @@ def get_mpstat(client):
     #Average:       3    2.00    0.00    1.00    0.00    0.00    0.00    0.00    0.00   97.00
 
     # Beware of the export!
-    stdin, stdout, stderr = client.exec_command('export LC_LANG=C && unset LANG && LC_NUMERIC=en_US.UTF-8 mpstat -P ALL 1 1')
+    stdin, stdout, stderr = client.exec_command('LC_LANG=C LANG=en_US.UTF-8 LC_NUMERIC=en_US.UTF-8 mpstat -P ALL 1 1')
     stats = {}
 
     pos = {'%usr':-1, '%nice':-1, '%sys':-1, '%iowait':-1, '%irq':-1, '%soft':-1, '%steal':-1, '%guest':-1, '%idle':-1}


### PR DESCRIPTION
Same problem than #59, the word "Average" is parsed and expected, using other locale (i.e spanish) the output is translated to "Media". Here is the output:

```
# LANG=es_ES.UTF-8 mpstat -P ALL 1 1
Linux 3.16.0-4-amd64 (demos) 	02/04/18 	_x86_64_	(2 CPU)

08:38:06     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
08:38:07     all    3,47    0,00    1,49    0,00    0,00    0,00    2,48    0,00    0,00   92,57
08:38:07       0    2,97    0,00    0,99    0,00    0,00    0,00    2,97    0,00    0,00   93,07
08:38:07       1    3,96    0,00    1,98    0,00    0,00    0,00    1,98    0,00    0,00   92,08

Media:       CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
Media:       all    3,47    0,00    1,49    0,00    0,00    0,00    2,48    0,00    0,00   92,57
Media:         0    2,97    0,00    0,99    0,00    0,00    0,00    2,97    0,00    0,00   93,07
Media:         1    3,96    0,00    1,98    0,00    0,00    0,00    1,98    0,00    0,00   92,08
```

Using english locales (as local environment) the output is fixed:

```
# LC_LANG=C LANG=en_US.UTF-8 LC_NUMERIC=en_US.UTF-8 mpstat -P ALL 1 1
Linux 3.16.0-4-amd64 (demos) 	04/02/18 	_x86_64_	(2 CPU)

08:42:41     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
08:42:42     all   19.19    0.00    3.03    0.00    0.00    0.00    1.52    0.00    0.00   76.26
08:42:42       0   24.24    0.00    3.03    0.00    0.00    1.01    2.02    0.00    0.00   69.70
08:42:42       1   12.87    0.00    3.96    0.00    0.00    0.00    1.98    0.00    0.00   81.19

Average:     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
Average:     all   19.19    0.00    3.03    0.00    0.00    0.00    1.52    0.00    0.00   76.26
Average:       0   24.24    0.00    3.03    0.00    0.00    1.01    2.02    0.00    0.00   69.70
Average:       1   12.87    0.00    3.96    0.00    0.00    0.00    1.98    0.00    0.00   81.19
```